### PR TITLE
Add Snap-to-Grid Functionality

### DIFF
--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -101,6 +101,13 @@ SVG.extend(SVG.Element, {
           y = constraint.minY
         else if (constraint.maxY != null && y > constraint.maxY - height)
           y = constraint.maxY - height
+          
+         /*  add snapping to grid if option is specified */
+         if (constraint.snapDistance != null && x % constraint.snapDistance != 0)
+           x = x - (x % constraint.snapDistance)
+         if (constraint.snapDistance != null && y % constraint.snapDistance != 0)
+           y = y - (y % constraint.snapDistance)
+
         
         /* move the element to its new position */
         element.move(x, y)


### PR DESCRIPTION
Dragging with snap-to-grid functionality is a pretty common requirement. This allows users to give a snapDistance option to the draggable call that makes drag motions snap to grid as they go.
