### PR TITLE
change the browser entry to `dist/svg.draggable.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/svg.draggable.js",
   "unpkg": "dist/svg.draggable.min.js",
   "jsdelivr": "dist/svg.draggable.min.js",
-  "browser": "src/svg.draggable.js",
+  "browser": "dist/svg.draggable.js",
   "module": "src/svg.draggable.js",
   "keywords": [
     "svg.js",


### PR DESCRIPTION
Not all browsers support ES6 code `e.g. IE11`, for example this prevents webpack vendor chuncks from including type errors in browsers that do not support ES6.