### PR TITLE
Allow type resolution when moduleResolution is bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@svgdotjs/svg.draggable.js",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "An extension for svg.js which allows to drag elements with your mouse",
   "type": "module",
   "main": "dist/svg.draggable.js",
   "module": "src/svg.draggable.js",
   "exports": {
     "import": "./src/svg.draggable.js",
-    "require": "./dist/svg.draggable.js"
+    "require": "./dist/svg.draggable.js",
+    "types": "./svg.draggable.js.d.ts"
   },
   "unpkg": "dist/svg.draggable.js",
   "jsdelivr": "dist/svg.draggable.js",


### PR DESCRIPTION
When tsconfig has "moduleResolution": "bundler" the types fail to register and calling draggable() errors out.

This patch has fixed mine. Please take a look if this really solves the issue.

Thank you